### PR TITLE
Add optional callback to Receiver.close()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .nyc_output
 coverage
+.idea

--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -102,8 +102,8 @@ export class Receiver extends EventEmitter {
     return this;
   }
 
-  public close(): this {
-    this.socket.close();
+  public close(callback?: () => any): this {
+    this.socket.close(callback);
     return this;
   }
 }


### PR DESCRIPTION
I'd like to propose a change to the `Receiver.close()` function. The underlying `Socket.close()` function accepts an optional callback which gets called when the socket is eventually closed.

~~Since reconfiguring the receiver is not possible, we need to close it first, create a new instance and start it again.~~ _Although possible to reconfigure universes to listen to it would be nice to be able to wait for `Socket.close()`._ As of now there is no possibility to wait for the socket to be closed, therefore when calling `Receiver.start()` on a new instance the port is still occupied (although using `reuseAddr: true` for that matter...).

This could also be implemented using events but since `Socket.close()` already offers that feature I figured that would be the easiest way.