### PR TITLE
Add sender interface selection support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,8 +104,8 @@ async function main() {
       1: 100,
       2: 50,
       3: 0,
-    }
-    sourceName: "My NodeJS app" // optional. LED lights will use this as the name of the source lighting console.
+    },
+    sourceName: "My NodeJS app", // optional. LED lights will use this as the name of the source lighting console.
     priority: 100, // optional. value between 0-200, in case there are other consoles broadcasting to the same universe
   });
 
@@ -116,14 +116,15 @@ main(); // wrapped in a main() function so that we can `await` the promise
 
 ```
 
-### Table 3 - Options for sender
+### Table 3 - Options for Sender
 
 | Name                   | Type      | Purpose                                                                                                    | Default |
 | ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------- | ------- |
 | `universe`             | `number`  | Required. The universes to listen to. Must be within 1-63999                                               | `[]`    |
 | `port`                 | `number`  | Optional. The multicast port to use. All professional consoles broadcast to the default port.              | `5568`  |
-| `reuseAddr`            | `boolean` | Optional. Allow multiple programs on your computer to listen to the same sACN universe.                    |
+| `reuseAddr`            | `boolean` | Optional. Allow multiple programs on your computer to send to the same sACN universe.                      |
 | `defaultPacketOptions` | `object`  | Optional. You can specify options like `sourceName`, `cid`, and `priority` here instead of on every packet |
+| `iface`                | `string`  | Optional. Specifies the IPv4 address of the network interface/card to use.                                 | OS default interface (=active internet connection)
 
 # Contribute
 

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -58,11 +58,14 @@ export class Sender {
     this.defaultPacketOptions = defaultPacketOptions;
 
     this.socket = createSocket({ type: 'udp4', reuseAddr });
-    this.socket.bind(port, () => { // need to bind socket first
-      if (iface) { // check here to prevent different behavior due to socket.bind() side effects
-        this.socket.setMulticastInterface(iface);
-      }
-    });
+
+    if (iface || reuseAddr) { // prevent different behavior due to socket.bind() side effects, but binding the socket when reuseAddr: false could cause problems
+      this.socket.bind(port, () => { // need to bind socket first
+        if (iface) {
+          this.socket.setMulticastInterface(iface);
+        }
+      });
+    }
 
     if (minRefreshRate) {
       this.#loopId = setInterval(() => this.reSend(), 1000 / minRefreshRate);

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -17,6 +17,9 @@ interface Props {
 
   /** some options can be sepecified when you instantiate the sender, instead of sepecifying them on every packet */
   defaultPacketOptions?: Pick<Options, 'cid' | 'sourceName' | 'priority'>;
+
+  // IPv4 address of the network interface
+  iface?: string,
 }
 
 export class Sender {
@@ -47,6 +50,7 @@ export class Sender {
     reuseAddr = false,
     minRefreshRate = 0,
     defaultPacketOptions,
+    iface,
   }: Props) {
     this.port = port;
     this.universe = universe;
@@ -54,6 +58,11 @@ export class Sender {
     this.defaultPacketOptions = defaultPacketOptions;
 
     this.socket = createSocket({ type: 'udp4', reuseAddr });
+    this.socket.bind(port, () => { // need to bind socket first
+      if (iface) { // check here to prevent different behavior due to socket.bind() side effects
+        this.socket.setMulticastInterface(iface);
+      }
+    });
 
     if (minRefreshRate) {
       this.#loopId = setInterval(() => this.reSend(), 1000 / minRefreshRate);


### PR DESCRIPTION
The additional `iface` option supports the selection of the network interface to send on.

Usage: see readme.md:127

Fixed four minor mistakes in readme.md (lines 107,108,119 and 125)

