### PR TITLE
🏷️ version bump to 4.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sacn",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sacn",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sacn",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "💡 🎭 Send and Receive sACN data (DMX over IP)",
   "author": "Kyle Hensel",
   "license": "Apache-2.0",


### PR DESCRIPTION
Hey @k-yle,

I wanted to use the new `useRawDmxValues` Option when I noticed it not being published to npm yet thus being committed to the `main` branch. This is a minor version bump to 4.5.0 for recent changes to be published to npm. 🙌

Thank you already for merging! 🙏

Best regards,
@lukas-runge

