### PR TITLE
✨ handle resend errors

### DIFF
--- a/src/sender.ts
+++ b/src/sender.ts
@@ -67,7 +67,7 @@ export class Sender extends EventEmitter {
 
   private sequence = 0;
 
-  private resendStatus = false;
+  public resendStatus = false;
 
   #loopId: NodeJS.Timeout | undefined;
 

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -48,6 +48,18 @@ export namespace Sender {
      */
     useUnicastDestination?: string;
   }
+
+  export interface EventMap {
+    changedResendStatus: boolean;
+    error: Error;
+  }
+}
+
+export declare interface Sender {
+  on<K extends keyof Sender.EventMap>(
+    type: K,
+    listener: (event: Sender.EventMap[K]) => void,
+  ): this;
 }
 
 export class Sender extends EventEmitter {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -48,6 +48,9 @@ describe('Receiver & Sender (integration test)', () => {
     try {
       const received: Packet[] = [];
       const errors: Error[] = [];
+      const receivedEvents: boolean[] = [];
+      Tx.on('changedResendStatus', (event) => receivedEvents.push(event));
+      Tx.on('error', (ex) => errors.push(ex));
       Rx.on('packet', (packet) => received.push(packet));
       collectErrors(Rx, errors);
 
@@ -58,6 +61,8 @@ describe('Receiver & Sender (integration test)', () => {
 
       assert.strictEqual(errors.length, 0);
       assert.strictEqual(received.length, 4); // send at 0s, 1s, 2s, 3s. Then at 3.5s we stop
+      assert.strictEqual(receivedEvents.length, 1);
+      assert.deepStrictEqual(receivedEvents[0], true);
       assert.deepStrictEqual(received[0]!.payload, { 1: 100 });
       assert.deepStrictEqual(received[1]!.payload, { 1: 100 });
       assert.deepStrictEqual(received[2]!.payload, { 1: 100 });


### PR DESCRIPTION
Hi @k-yle,

when using the `minRefreshRate` feature to resend packets continuously the socket might throw errors. One example would be disconnecting and reconnecting the ethernet connection. In this case the unhandled error would crash the whole application and there would be no way for users of the library to catch those and handle those appropriately. This is why I implemented two events that help users handling those cases:

1. `error`: contains the `Error` object for further handling
2. `changedResendStatus`: to gracefully recover from disconnection events without necessarily needing to destroy and recreate the `Sender` instance.

Best regards,
@lukas-runge 