### PR TITLE
fix switch back to `0` in HTP merging

### DIFF
--- a/src/merging.ts
+++ b/src/merging.ts
@@ -236,7 +236,7 @@ export class MergingReceiver extends Receiver {
       ) {
         for (let ch = 1; ch <= 512; ch += 1) {
           const newValue = packet.payload[ch] || 0;
-          if ((mergedData[ch] ?? 0) < newValue) {
+          if ((mergedData[ch] ?? 0) <= newValue) {
             mergedData[ch] = newValue;
           }
         }

--- a/test/merging.test.ts
+++ b/test/merging.test.ts
@@ -42,6 +42,8 @@ describe('HTP', () => {
         }),
       },
     });
+    deleteZeros(merged);
+
     expect(merged).toStrictEqual({
       // HTP applies to the whole packet, so channel 4 is 0, instead of 204
       // referenceData is irrelevant for HTP, so channel 5 is 0, instead of 5
@@ -66,6 +68,8 @@ describe('HTP', () => {
         }),
       },
     });
+    deleteZeros(merged);
+
     expect(merged).toStrictEqual({
       1: 201,
       2: 202,


### PR DESCRIPTION
Value `0` was never set since the condition to be smaller than the reference `0` is never met. This led to being `undefined` and missing keys within the change-events.